### PR TITLE
remove default values for date and datetime fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 0.5.2 (2019-8-14)
 
+- Remove default empty value for date and datetime fields
+  [erral]
+
 - Fix PloneImageField snippet for supermodel files
   [erral]
 

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -141,7 +141,6 @@
             "    description=_(",
             "        u'${4}',",
             "    ),",
-            "    default='',",
             "    required=${6|False,True|},",
             "    readonly=${7|False,True|},",
             ")"
@@ -157,7 +156,6 @@
             "    description=_(",
             "        u'${4}',",
             "    ),",
-            "    default='',",
             "    required=${6|False,True|},",
             "    readonly=${7|False,True|},",
             ")"

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -141,6 +141,7 @@
             "    description=_(",
             "        u'${4}',",
             "    ),",
+            "    # defaultFactory=${5:get_default_${1}},",
             "    required=${6|False,True|},",
             "    readonly=${7|False,True|},",
             ")"
@@ -156,6 +157,7 @@
             "    description=_(",
             "        u'${4}',",
             "    ),",
+            "    # defaultFactory=${5:get_default_${1}},",
             "    required=${6|False,True|},",
             "    readonly=${7|False,True|},",
             ")"


### PR DESCRIPTION
Otherwise you get some strange exception when starting the instance:

```
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/var/csmant/instances/XXXX.buildout/parts/instance/etc/site.zcml", line 16.2-16.23
    ZopeXMLConfigurationError: File "/var/csmant/downloads/eggs/Products.CMFPlone-4.3.4.1-py2.7.egg/Products/CMFPlone/configure.zcml", line 98.4-102.10
    ZopeXMLConfigurationError: File "/var/csmant/instances/XXX.buildout/src/XXX.XXX/XXX/XXX/configure.zcml", line 17.4-17.39
    ZopeXMLConfigurationError: File "/var/csmant/instances/XXX.buildout/src/XXX.XXX/XXX/XXX/configure.zcml", line 26.4-26.29
    WrongType: ('', <type 'datetime.datetime'>, '')
 
```