### PR TITLE
remove default value from NamedBlobFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 0.5.5 (UNRELEASED)
 
+- Remove default value from the NamedBlobFile field
+  [erral]
+
 - Add RadioFieldWidget to the available widget list
   [erral]
 

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -285,7 +285,6 @@
             "    description=_(",
             "        u'${4}',",
             "    ),",
-            "    default='',",
             "    required=${6|False,True|},",
             "    readonly=${7|False,True|},",
             ")"


### PR DESCRIPTION
adding a `default=""` to a NamedBlobFile field creates a very strange and unmeaningful error when importing the generic setup profile such as the following: 

```
2021-05-11 08:58:30,966 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1620716310.96576020.18026975578666038 http://localhost:8080/Plone/portal_setup/manage_importSelectedSteps
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 570, in manage_importSelectedSteps
  Module Products.GenericSetup.tool, line 370, in runImportStepFromProfile
  Module Products.GenericSetup.tool, line 1290, in _doRunImportStep
   - __traceback_info__: typeinfo
  Module Products.CMFCore.exportimport.typeinfo, line 221, in importTypesTool
  Module Products.GenericSetup.utils, line 908, in importObjects
   - __traceback_info__: portal_types
  Module Products.GenericSetup.utils, line 904, in importObjects
   - __traceback_info__: types/Curso
  Module Products.GenericSetup.utils, line 541, in _importBody
  Module Products.CMFCore.exportimport.typeinfo, line 60, in _importNode
  Module Products.GenericSetup.utils, line 839, in _initProperties
  Module plone.dexterity.fti, line 310, in _updateProperty
  Module plone.dexterity.utils, line 54, in resolveDottedName
  Module zope.dottedname.resolve, line 45, in resolve
  Module muformacionprofesionales.addon.content.curso, line 12, in <module>
  Module muformacionprofesionales.addon.content.curso, line 413, in ICurso
  Module plone.namedfile.field, line 110, in __init__
  Module zope.schema._bootstrapfields, line 1098, in __init__
  Module zope.schema._bootstrapfields, line 267, in __init__
  Module zope.schema._bootstrapfields, line 85, in __set__
  Module zope.schema._bootstrapfields, line 292, in validate
  Module plone.namedfile.field, line 113, in _validate
  Module zope.schema._bootstrapfields, line 1106, in _validate
  Module zope.schema._bootstrapfields, line 338, in _validate
zope.schema._bootstrapinterfaces.WrongType: ('', <class 'plone.namedfile.file.NamedBlobFile'>, '')
```

Removing the default value fixes it.