### PR TITLE
align RichText import with the one created by bobtemplates.plone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 0.5.5 (UNRELEASED)
 
+- Align RichText import with the import created by plonecli/bobtemplates.plone
+  [erral]
+
 - Add RadioFieldWidget to the available widget list
   [erral]
 

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -492,8 +492,8 @@
     },
     "RichText Field (plone.app.textfield)": {
         "body": [
-            "# Make sure to import: plone.app.textfield",
-            "${1:name} = ${2:textfield.RichText}(",
+            "# Make sure to import: from plone.app.textfield import RichText",
+            "${1:name} = ${2:RichText}(",
             "    title=_(",
             "        u'${3}',",
             "    ),",


### PR DESCRIPTION
When using in conjunction with bobtemplates.plone this templates creates the [following import](https://github.com/plone/bobtemplates.plone/blob/master/bobtemplates/plone/content_type/content/%2Bdexterity_type_name_normalized%2B.py.bob#L3)
```
from plone.app.textfield import RichText
```

With this change we keep both packages in sync and the user of these snippets doesn't need to change anything after introducing the snippet.

